### PR TITLE
edited remote chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,4 +70,8 @@ resource "helm_release" "helm_remote_deployment" {
   chart         = "${var.deployment_path}"
   timeout       = "${local.timeout}"
   recreate_pods = "${local.recreate_pods}"
+  values = [
+    "${file("${var.values}")}"
+  ]
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,7 @@ variable "recreate_pods" {
    default     = "false"
  }
  
+variable "values" {
+   default     = "values.yaml"
+ }
+ 


### PR DESCRIPTION
Hello everyone,
we modified terraform-helm-chart module to update values.yaml for remote charts. Currently, Our remote charts is deployable with clients values.yaml file. We were  able to test and  update values.yaml and do remote chart deployment.