### PR TITLE
added version for remote deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ resource "helm_release" "helm_remote_deployment" {
   chart         = "${var.deployment_path}"
   timeout       = "${local.timeout}"
   recreate_pods = "${local.recreate_pods}"
+  version       = "${var.release_version}"
   values = [
     "${file("${var.values}")}"
   ]


### PR DESCRIPTION
added a new line for chart version inside the remote deployment.

You do not need to pull the code to try as it was edited for remote deployment. after merge we will release it on terraform registry and try remote deployment with version option.