### PR TITLE
updated helm version to 0.10.6

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 
 # required helm provider for this module 
 provider "helm" { 
-    version = "0.10.4"
+    version = "0.10.6"
 }
 
 # Required provider for local files 


### PR DESCRIPTION
Hello Team!

I've updated the version.tf provider "helm" to version "0.10.6".  This has been tested by creating a duplicate terraform-helm-chart with the version update on Tuba's repo and replacing our source to her version (source  = "tuyalou/chart/helm").  Jenkins jobs now runs without issue.  Please review and we will need to push to master and create a new version release.  If you have questions please let me know.

Thank you!
Kelly Salrin