### PR TITLE
helm module version changed

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 
 # required helm provider for this module 
 provider "helm" { 
-    version = "0.10.6"
+    version = "1.3.2"
 }
 
 # Required provider for local files 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 
 # required helm provider for this module 
 provider "helm" { 
-    version = "1.3.2"
+    version = "1.3.2" #previous version was "0.10.6"
 }
 
 # Required provider for local files 


### PR DESCRIPTION
Hello team, 

Our terraform helm module version is changed to v1.3.2. 
With the new version of the module, we can use both helm v2 and v3 to deploy our applications. 

Please review, check from your side and approve PR. 
If you have any questions or comments feel free to write them down in the comments section.

Thank you