### PR TITLE
Deprecate listed tools from common tools (terraform-helm-chart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ module "helm_deploy" {
   deployment_endpoint    = "example.fuchicorp.com"
   deployment_path        = "example"
   release_version        = "0.0.4"                 
-
 }
 EOF
 ```
@@ -169,7 +168,6 @@ Next create an simple output file named `output.tf` and copy and paste the follo
 output "success" {
   value = "${module.helm_remote_deployment.success_output}"
 }
-
 ```
 
                Developed by FuchiCorp DevOps team, Enjoy using it. 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This terraform module will help you deploy the helm charts on local.
 
 - [Custom Values](#custom-variable-deployment)
 
-  
-
 ## Requirements
 
 Terraform >= 0.11.7
@@ -68,20 +66,17 @@ output "success" {
 
 ```
 
-follow the file path 
-
+follow the file path:
 ```yaml
 ./module.tf
 ./output.tf
 ./charts/
-    /example ## Your chart location 
-      /Chart.yaml
-      /charts
-      /templates
-      /values.yaml
+  /example ## Your chart location 
+    /Chart.yaml
+    /charts
+    /templates
+    /values.yaml
 ```
-
-
 
 ## Variables
 
@@ -94,7 +89,7 @@ For more info, please see the [variables file](variables.tf).
 | `deployment_endpoint` | Ingress endpoint `example.fuchicorp.com` | `(Required)` | `domain/string` |
 | `deployment_path` | path for helm chart on local | `(Required)` | `string` |
 | `release_version` | Specify the exact chart version to install. | `(Required)` | `string` |
-| `remote_chart` | Specify if you want to deploy the remote chart to `"True"` default value is `"False"`| `(Optional)` | `bool` |
+| `enabled` | Specify if you want to deploy the enabled to `"true"` default value is `"false"`| `(Optional)` | `bool` |
 | `values` | Name of the values.yaml file | `(Optional)` | `string` |
 | `template_custom_vars` | Template custom veriables you can modify variables by parsting the `template_custom_vars` | `(Optional)` | `map` |
 | `env_vars` | Environment veriable for the containers takes map | `(Optional)` | `map` |
@@ -108,15 +103,14 @@ For more info, please see the [variables file](variables.tf).
 ```
 module "helm_deploy" {
   # source = "git::https://github.com/fuchicorp/helm-deploy.git"
-  source  = "fuchicorp/chart/helm"
+  source                 = "fuchicorp/chart/helm"
   deployment_name        = "artemis-deployment"
   deployment_environment = "dev"
   deployment_endpoint    = "artemis.fuchicorp.com"
   deployment_path        = "artemis"
   release_version        = "0.0.4"                  
-
-
-  template_custom_vars = {
+  enabled                = "true"
+  template_custom_vars   = {
     deployment_image = "nginx"
   }
 }
@@ -161,13 +155,13 @@ Please follow the steps to configure `module.tf` and `output.tf`
 ```
 module "helm_remote_deployment" {
   source = "fuchicorp/chart/helm"
-  deployment_name        = "example-deployment"     ## The name of the deployment
-  deployment_environment = "dev"                    ## Name of the namespace
-  deployment_endpoint    = "example.fuchicorp.com"  ## Ingress endpoint
-  deployment_path        = "stable/jenkins"         ## Path for helm chart
-  release_version        = "0.0.4"                  ## Chart version
-  remote_chart           = "true"
-  values                 = "values.yaml"            ## your values.yaml file 
+  deployment_name        = "example-deployment"     # The name of the deployment
+  deployment_environment = "dev"                    # Name of the namespace
+  deployment_endpoint    = "example.fuchicorp.com"  # Ingress endpoint
+  deployment_path        = "stable/jenkins"         # Path for helm chart
+  release_version        = "0.0.4"                  # Chart version
+  enabled                = "true"                   # Deploy resource
+  values                 = "values.yaml"            # your values.yaml file 
 }
 ```
 Next create an simple output file named `output.tf` and copy and paste the following:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ module "helm_deploy" {
   deployment_name        = "example-deployment"
   deployment_environment = "dev"
   deployment_endpoint    = "example.fuchicorp.com"
-  deployment_path        = "example"
+  deployment_path        = "./charts/example"
+  enabled                = "true"
   release_version        = "0.0.4"                 
 }
 EOF
@@ -106,7 +107,7 @@ module "helm_deploy" {
   deployment_name        = "artemis-deployment"
   deployment_environment = "dev"
   deployment_endpoint    = "artemis.fuchicorp.com"
-  deployment_path        = "artemis"
+  deployment_path        = "./charts/artemis"
   release_version        = "0.0.4"                  
   enabled                = "true"
   template_custom_vars   = {
@@ -151,23 +152,5 @@ Please follow the steps to configure `module.tf` and `output.tf`
 ./values.yaml 
 ```
 `module.tf` file should look like this
-```
-module "helm_remote_deployment" {
-  source = "fuchicorp/chart/helm"
-  deployment_name        = "example-deployment"     # The name of the deployment
-  deployment_environment = "dev"                    # Name of the namespace
-  deployment_endpoint    = "example.fuchicorp.com"  # Ingress endpoint
-  deployment_path        = "stable/jenkins"         # Path for helm chart
-  release_version        = "0.0.4"                  # Chart version
-  enabled                = "true"                   # Deploy resource
-  values                 = "values.yaml"            # your values.yaml file 
-}
-```
-Next create an simple output file named `output.tf` and copy and paste the following:
-```
-output "success" {
-  value = "${module.helm_remote_deployment.success_output}"
-}
-```
 
                Developed by FuchiCorp DevOps team, Enjoy using it. 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For more info, please see the [variables file](variables.tf).
 | `deployment_endpoint` | Ingress endpoint `example.fuchicorp.com` | `(Required)` | `domain/string` |
 | `deployment_path` | path for helm chart on local | `(Required)` | `string` |
 | `release_version` | Specify the exact chart version to install. | `(Required)` | `string` |
-| `enabled` | Specify if you want to deploy the enabled to `"true"` default value is `"false"`| `(Optional)` | `bool` |
+| `enabled` | Specify if you want to deploy the enabled to `"true"` or `"false"` default value is `"true"`| `(Optional)` | `bool` |
 | `values` | Name of the values.yaml file | `(Optional)` | `string` |
 | `template_custom_vars` | Template custom veriables you can modify variables by parsting the `template_custom_vars` | `(Optional)` | `map` |
 | `env_vars` | Environment veriable for the containers takes map | `(Optional)` | `map` |

--- a/README.md
+++ b/README.md
@@ -136,21 +136,4 @@ Output file will be:
 
 You can see the `repository` replaced to the right value
 
-## If you would like to deploy remote chart
-
-REMOTE CHARTS are available on versions `"0.0.4"` and up.
-
-In order to deploy remote charts, you should have your own `values.yaml` file,
-
-`module.tf` and `output.tf` in the same folder.  
-
-Please follow the steps to configure `module.tf` and `output.tf`
-
-```yaml
-./module.tf  
-./output.tf
-./values.yaml 
-```
-`module.tf` file should look like this
-
                Developed by FuchiCorp DevOps team, Enjoy using it. 

--- a/main.tf
+++ b/main.tf
@@ -1,50 +1,44 @@
 locals {
   required_values = {
-    ## Deployment endpoint for ingress
+    # Deployment endpoint for ingress
     deployment_endpoint = "${lower(var.deployment_endpoint)}"
-
-    ## <deployment_name> for backend.tf and also release name
-    deployment_name = "${lower(var.deployment_name)}"
-
-    ## <env_vars> for global environment variables takes map()
-    env_vars = "${trimspace(join("\n", data.template_file.env_vars.*.rendered))}"
+    # <deployment_name> for backend.tf and also release name
+    deployment_name     = "${lower(var.deployment_name)}"
+    # <env_vars> for global environment variables takes map()
+    env_vars            = "${trimspace(join("\n", data.template_file.env_vars.*.rendered))}"
   }
-
-  ## When all requred values all deffined then also will incloude users values
+  # When all requred values all deffined then also will incloude users values
   template_all_values = "${merge(local.required_values, var.template_custom_vars)}"
-
-  timeout       = "${var.timeout}"
-  recreate_pods = "${var.recreate_pods}"
+  timeout             = "${var.timeout}"
+  recreate_pods       = "${var.recreate_pods}"
 }
 
-## template_file.env_vars just converting to right values
+# template_file.env_vars just converting to right values
 data "template_file" "env_vars" {
   count    = "${length(keys(var.env_vars))}"
   template = "  $${key}: \"$${value}\""
-
   vars {
     key   = "${element(keys(var.env_vars), count.index)}"
     value = "${element(values(var.env_vars), count.index)}"
   }
 }
 
-## template_file.chart_values_template actual values.yaml file from charts
+# template_file.chart_values_template actual values.yaml file from charts
 data "template_file" "chart_values_template" {
-  count = "${var.remote_chart == "true" ? 0 : 1 }"
-  template = "${file("charts/${var.deployment_path}/values.yaml")}"
-
-  vars = "${local.template_all_values}"
+  count    = "${var.enabled == "true" ? 1 : 0 }"
+  template = "${file("${var.deployment_path}/values.yaml")}"
+  vars     = "${local.template_all_values}"
 }
 
-## This resource was disabled and moved to output please see the ticket
-## https://github.com/fuchicorp/terraform-helm-chart/issues/21
+# This resource was disabled and moved to output please see the ticket
+# https://github.com/fuchicorp/terraform-helm-chart/issues/21
 # resource "local_file" "deployment_values" {
-#   content  = "${trimspace(data.template_file.chart_values_template.rendered)}"
+#   content  = "${trimspace(data.template_file.chart_values_template.0.rendered)}"
 #   filename = "${path.module}/${var.deployment_name}-values.yaml"
 # }
 
 output "deployment_values" {
-  value = "${data.template_file.chart_values_template.0.rendered}"
+  value       = "${data.template_file.chart_values_template.*.rendered}"
   description = "This output is for storing values.yaml"
 }
 
@@ -52,32 +46,16 @@ locals {
   trigger = "${var.trigger == "UUID" ? uuid() : var.trigger}"
 }
 
-## helm_release.helm_deployment is actual helm deployment
+# helm_release.helm_deployment is actual helm deployment
 resource "helm_release" "helm_deployment" {
-  count = "${var.remote_chart == "true" ? 0 : 1 }"
-  name          = "${var.deployment_name}-${var.deployment_environment}"
-  namespace     = "${var.deployment_environment}"
-  chart         = "./charts/${var.deployment_path}"
-  timeout       = "${local.timeout}"
-  recreate_pods = "${local.recreate_pods}"
-  version       = "${var.release_version}"
-
-  values = [
-    "${trimspace(data.template_file.chart_values_template.rendered)}",
-  ]
-}
-
-## helm_release.helm_deployment is actual helm deployment
-resource "helm_release" "helm_remote_deployment" {
-  count = "${var.remote_chart == "true" ? 1 : 0 }"
+  count         = "${var.enabled == "true" ? 1 : 0}"
   name          = "${var.deployment_name}-${var.deployment_environment}"
   namespace     = "${var.deployment_environment}"
   chart         = "${var.deployment_path}"
   timeout       = "${local.timeout}"
   recreate_pods = "${local.recreate_pods}"
   version       = "${var.release_version}"
-  values = [
-    "${file("${var.values}")}"
+  values        = [
+    "${trimspace(data.template_file.chart_values_template.rendered)}",
   ]
-
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "release_version" {
 }
 
 variable "enabled" {
-  default = "false"
+  default = "true"
 }
 
 variable "values" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,19 @@
-## The name of the deployment
+# The name of the deployment
 variable "deployment_name" {
   description = "The name of the deployment"
 }
 
-## The name of the environment
+# The name of the environment
 variable "deployment_environment" {
   description = "The name of the environment"
 }
 
-## Chart location or chart name
+# Chart location or chart name
 variable "deployment_path" {
   description = "Chart location or chart name <stable/example>"
 }
 
-## Endpoint for the application
+# Endpoint for the application
 variable "deployment_endpoint" {
   description = "Endpoint for the application"
 }
@@ -39,18 +39,16 @@ variable "timeout" {
 variable "recreate_pods" {
   default = false
 }
- variable "release_version" {
-   description = "(Required) Specify the exact chart version to install"
-   default     = " 0.1.0"
-  
- }
 
+variable "release_version" {
+  default     = " 0.1.0"
+  description = "(Required) Specify the exact chart version to install"
+}
 
- variable "remote_chart" {
-   default     = "false"
- }
- 
+variable "enabled" {
+  default = "false"
+}
+
 variable "values" {
-   default     = "values.yaml"
- }
- 
+  default = "values.yaml"
+} 

--- a/variables.tf
+++ b/variables.tf
@@ -19,36 +19,37 @@ variable "deployment_endpoint" {
 }
 
 variable "template_custom_vars" {
-  type    = "map"
-  default = {}
+  type        = "map"
+  default     = {}
 }
 
 variable "env_vars" {
-  type    = "map"
-  default = {}
+  type        = "map"
+  default     = {}
 }
 
 variable "trigger" {
-  default = "UUID"
+  default     = "UUID"
 }
 
 variable "timeout" {
-  default = "400"
+  default     = "400"
 }
 
 variable "recreate_pods" {
-  default = false
+  default     = false
 }
 
 variable "release_version" {
-  default     = " 0.1.0"
   description = "(Required) Specify the exact chart version to install"
+  default     = " 0.1.0"
+
 }
 
 variable "enabled" {
-  default = "true"
+  default     = "true"
 }
 
 variable "values" {
-  default = "values.yaml"
-} 
+  default     = "values.yaml"
+}


### PR DESCRIPTION
Hello, this is a PR to replace variable `remote_chart` to `enabled` and getting rid of `helm_remote_deployment` and using only `helm_deployment` and updating `deployment_path` to make it more viable.

This pull request is connected to issue: https://github.com/fuchicorp/common_tools/issues/621